### PR TITLE
Introduces a merge function that merges an array of states into a single new state

### DIFF
--- a/libs/ngx-http-request-state/README.md
+++ b/libs/ngx-http-request-state/README.md
@@ -116,7 +116,6 @@ Consider the following example where we assume we have no control over `MyDataSe
 // Third party
 @Injectable()
 export class MyDataService {
-
   constructor(private httpClient: HttpClient) {}
 
   getMyData(someParameter: any) {
@@ -128,16 +127,16 @@ export class MyDataService {
 
 // Our component
 export class SomeComponent {
-  readonly myDataCollection$ = combineLatest([
-    this.myDataService.getMyData("red"),
-    this.myDataService.getMyData("blue"),
+  readonly myDataCollection$ = combineLatest([
+    this.myDataService.getMyData('red'),
+    this.myDataService.getMyData('blue'),
   ]).pipe(
-    map(states =>
+    map((states) =>
       mergeStates(states, (dataArray) => {
         // Merge list of data together then return a new instance of MyData
       })
     )
-  )
+  );
 
   constructor(private myDataService: MyDataService) {}
 }
@@ -158,25 +157,27 @@ Example:
 
 ```typescript
 export class SomeComponent {
-  readonly myDataCollection$ = combineLatest([
-    this.myDataService.getMyData("will-fail"),
-    this.myDataService.getMyData("will-also-fail"),
-    this.myDataService.getMyData("blue"),
+  readonly myDataCollection$ = combineLatest([
+    this.myDataService.getMyData('will-fail'),
+    this.myDataService.getMyData('will-also-fail'),
+    this.myDataService.getMyData('blue'),
   ]).pipe(
-    map(states =>
-      mergeStates(states, (dataArray) => {
-        // Merge list of data together then return a new instance of MyData
-      }, (errors) => {
-        // Combine the errors and return a new instance of HttpErrorResponse or Error
-      })
+    map((states) =>
+      mergeStates(
+        states,
+        (dataArray) => {
+          // Merge list of data together then return a new instance of MyData
+        },
+        (errors) => {
+          // Combine the errors and return a new instance of HttpErrorResponse or Error
+        }
+      )
     )
-  )
+  );
 
   constructor(private myDataService: MyDataService) {}
 }
 ```
-
-
 
 ### switchMap safety
 

--- a/libs/ngx-http-request-state/README.md
+++ b/libs/ngx-http-request-state/README.md
@@ -150,7 +150,7 @@ Using `mergeStates` allows you to act "inside" the `HttpRequestState`, directly 
 As long as one of the states are loading, the resulting merged state will be a `LoadingState`.
 When all finish successfully, the callback of the second argument is called with all the available values.
 
-If an error occur in any of the requests, the merged state will be an `ErrorState`.
+If an error occurs in any of the requests, the merged state will be an `ErrorState`.
 By default the first of the errors will be returned.
 It is possible to override this with the third argument.
 

--- a/libs/ngx-http-request-state/src/index.ts
+++ b/libs/ngx-http-request-state/src/index.ts
@@ -2,3 +2,4 @@ export * from './lib/model';
 export * from './lib/builders';
 export * from './lib/type-guards';
 export * from './lib/operators';
+export * from './lib/merge';

--- a/libs/ngx-http-request-state/src/lib/merge.spec.ts
+++ b/libs/ngx-http-request-state/src/lib/merge.spec.ts
@@ -1,5 +1,5 @@
-import { loadedState, loadingState } from "./builders";
-import { isLoadedState, isLoadingState } from "./type-guards";
+import { errorState, loadedState, loadingState } from "./builders";
+import { isErrorState, isLoadedState, isLoadingState } from "./type-guards";
 import { mergeStates} from "./merge"
 
 const sum = (values: number[]) => values.reduce((a, b) => a + b, 0)
@@ -27,5 +27,36 @@ describe('merge', () => {
 
     expect(isLoadedState(merged)).toBe(true);
     expect(merged.value).toBe(42 + 1337)
+  });
+
+  it('should return error state if one state fails', () => {
+    const loading = loadingState();
+    const loaded = loadedState(42);
+    const error = errorState(new Error("Test"))
+
+    const mergedLoadingError = mergeStates([loading, error], sum);
+
+    expect(isErrorState(mergedLoadingError)).toBe(true);
+    expect(mergedLoadingError.error.message).toBe("Test");
+
+    const mergedLoadedError = mergeStates([loaded, error], sum);
+
+    expect(isErrorState(mergedLoadedError)).toBe(true);
+    expect(mergedLoadedError.error.message).toBe("Test");
+  });
+
+
+  it('should return error state with custom error in case mergeErrors is supplied', () => {
+    const loaded = loadedState(42);
+    const error1 = errorState(new Error("Goodbye"));
+    const error2 = errorState(new Error("world"));
+
+    const mergedLoadingError = mergeStates([loaded, error1, error2], sum, (errors) => {
+      const msg = errors.map(error => error.message).join(" ")
+      return new Error(msg)
+    });
+
+    expect(isErrorState(mergedLoadingError)).toBe(true);
+    expect(mergedLoadingError.error.message).toBe("Goodbye world");
   });
 })

--- a/libs/ngx-http-request-state/src/lib/merge.spec.ts
+++ b/libs/ngx-http-request-state/src/lib/merge.spec.ts
@@ -1,0 +1,31 @@
+import { loadedState, loadingState } from "./builders";
+import { isLoadedState, isLoadingState } from "./type-guards";
+import { mergeStates} from "./merge"
+
+const sum = (values: number[]) => values.reduce((a, b) => a + b, 0)
+
+describe('merge', () => {
+  it('should return a loadingState if one of the inputs are loading state', () => {
+    const loading = loadingState<number>();
+    const loaded = loadedState(42);
+
+    const mergedLoadingLoading = mergeStates([loading, loading], sum);
+    expect(isLoadingState(mergedLoadingLoading)).toBe(true);
+
+    const mergedLoadingLoaded = mergeStates([loading, loaded], sum);
+    expect(isLoadingState(mergedLoadingLoaded)).toBe(true);
+
+    const mergeLoadedLoading = mergeStates([loaded, loading], sum);
+    expect(isLoadingState(mergeLoadedLoading)).toBe(true);
+  });
+
+  it('should return merged loadedState if all inputs are loaded state', () => {
+    const s1 = loadedState(42);
+    const s2 = loadedState(1337);
+
+    const merged = mergeStates([s1, s2], sum);
+
+    expect(isLoadedState(merged)).toBe(true);
+    expect(merged.value).toBe(42 + 1337)
+  });
+})

--- a/libs/ngx-http-request-state/src/lib/merge.spec.ts
+++ b/libs/ngx-http-request-state/src/lib/merge.spec.ts
@@ -1,8 +1,8 @@
-import { errorState, loadedState, loadingState } from "./builders";
-import { isErrorState, isLoadedState, isLoadingState } from "./type-guards";
-import { mergeStates} from "./merge"
+import { errorState, loadedState, loadingState } from './builders';
+import { isErrorState, isLoadedState, isLoadingState } from './type-guards';
+import { mergeStates } from './merge';
 
-const sum = (values: number[]) => values.reduce((a, b) => a + b, 0)
+const sum = (values: number[]) => values.reduce((a, b) => a + b, 0);
 
 describe('merge', () => {
   it('should return a loadingState if one of the inputs are loading state', () => {
@@ -26,37 +26,40 @@ describe('merge', () => {
     const merged = mergeStates([s1, s2], sum);
 
     expect(isLoadedState(merged)).toBe(true);
-    expect(merged.value).toBe(42 + 1337)
+    expect(merged.value).toBe(42 + 1337);
   });
 
   it('should return error state if one state fails', () => {
     const loading = loadingState();
     const loaded = loadedState(42);
-    const error = errorState(new Error("Test"))
+    const error = errorState(new Error('Test'));
 
     const mergedLoadingError = mergeStates([loading, error], sum);
 
     expect(isErrorState(mergedLoadingError)).toBe(true);
-    expect(mergedLoadingError.error.message).toBe("Test");
+    expect(mergedLoadingError.error.message).toBe('Test');
 
     const mergedLoadedError = mergeStates([loaded, error], sum);
 
     expect(isErrorState(mergedLoadedError)).toBe(true);
-    expect(mergedLoadedError.error.message).toBe("Test");
+    expect(mergedLoadedError.error.message).toBe('Test');
   });
-
 
   it('should return error state with custom error in case mergeErrors is supplied', () => {
     const loaded = loadedState(42);
-    const error1 = errorState(new Error("Goodbye"));
-    const error2 = errorState(new Error("world"));
+    const error1 = errorState(new Error('Goodbye'));
+    const error2 = errorState(new Error('world'));
 
-    const mergedLoadingError = mergeStates([loaded, error1, error2], sum, (errors) => {
-      const msg = errors.map(error => error.message).join(" ")
-      return new Error(msg)
-    });
+    const mergedLoadingError = mergeStates(
+      [loaded, error1, error2],
+      sum,
+      (errors) => {
+        const msg = errors.map((error) => error.message).join(' ');
+        return new Error(msg);
+      }
+    );
 
     expect(isErrorState(mergedLoadingError)).toBe(true);
-    expect(mergedLoadingError.error.message).toBe("Goodbye world");
+    expect(mergedLoadingError.error.message).toBe('Goodbye world');
   });
-})
+});

--- a/libs/ngx-http-request-state/src/lib/merge.ts
+++ b/libs/ngx-http-request-state/src/lib/merge.ts
@@ -1,0 +1,56 @@
+import { HttpRequestState, LoadedState, ErrorState, LoadingState } from "./model"
+import { isLoadedState, isErrorState } from "./type-guards"
+
+
+/**
+ * Given an array of HttpRequestState<T>, merge them together into a new single HttpRequestState<T>,
+ * based on a supplied merging strategy of values (mergeValues) or of errors (mergeErrors).
+ *
+ * One can think of this function as allowing one to act "inside" the states, directly on the values or errors.
+ *
+ * Use this with combineLatest, instead of forkJoin, to get loading updates.
+ *
+ * @param states Array of states of the same type that should be merged together.
+ * @param mergeValues Handles how to merge values together when all states have loaded.
+ * @param mergeErrors Handles how to merge errors together in case one or more of the states end up in ErrorState.
+ *    If not specified, the first error is simply used as the error of the merged state
+ * @returns The merged HttpRequestState<T>
+ */
+export function merge<T>(
+  states: HttpRequestState<T>[],
+  mergeValues: (states: LoadedState<T>["value"][]) => LoadedState<T>["value"],
+  mergeErrors?: (states: ErrorState<T>["error"][]) => ErrorState<T>["error"],
+): HttpRequestState<T> {
+  if (states.every(isLoadedState)) {
+    const state: LoadedState<T> = {
+      isLoading: false,
+      value: mergeValues(states.map(s => s.value)),
+      error: undefined,
+    };
+    return state;
+  }
+
+  if (states.some(isErrorState)) {
+    if (mergeErrors === undefined) {
+      mergeErrors = (errors: ErrorState<T>["error"][]) => errors[0];
+    }
+
+    const errorStates = states.filter(isErrorState)
+    const state: ErrorState<T> = {
+      isLoading: false,
+      value: undefined,
+      error: mergeErrors(errorStates.map(s => s.error)),
+    };
+    return state;
+  };
+
+  // If one of the state is still not loaded and there are no errors
+  // the merged state is still considered loading.
+  const state: LoadingState<T> = {
+    isLoading: true,
+    value: undefined,
+    error: undefined,
+  };
+
+  return state;
+}

--- a/libs/ngx-http-request-state/src/lib/merge.ts
+++ b/libs/ngx-http-request-state/src/lib/merge.ts
@@ -16,7 +16,7 @@ import { isLoadedState, isErrorState } from "./type-guards"
  *    If not specified, the first error is simply used as the error of the merged state
  * @returns The merged HttpRequestState<T>
  */
-export function merge<T>(
+export function mergeStates<T>(
   states: HttpRequestState<T>[],
   mergeValues: (states: LoadedState<T>["value"][]) => LoadedState<T>["value"],
   mergeErrors?: (states: ErrorState<T>["error"][]) => ErrorState<T>["error"],

--- a/libs/ngx-http-request-state/src/lib/merge.ts
+++ b/libs/ngx-http-request-state/src/lib/merge.ts
@@ -1,6 +1,10 @@
-import { HttpRequestState, LoadedState, ErrorState, LoadingState } from "./model"
-import { isLoadedState, isErrorState } from "./type-guards"
-
+import {
+  HttpRequestState,
+  LoadedState,
+  ErrorState,
+  LoadingState,
+} from './model';
+import { isLoadedState, isErrorState } from './type-guards';
 
 /**
  * Given an array of HttpRequestState<T>, merge them together into a new single HttpRequestState<T>,
@@ -18,13 +22,13 @@ import { isLoadedState, isErrorState } from "./type-guards"
  */
 export function mergeStates<T>(
   states: HttpRequestState<T>[],
-  mergeValues: (states: LoadedState<T>["value"][]) => LoadedState<T>["value"],
-  mergeErrors?: (states: ErrorState<T>["error"][]) => ErrorState<T>["error"],
+  mergeValues: (states: LoadedState<T>['value'][]) => LoadedState<T>['value'],
+  mergeErrors?: (states: ErrorState<T>['error'][]) => ErrorState<T>['error']
 ): HttpRequestState<T> {
   if (states.every(isLoadedState)) {
     const state: LoadedState<T> = {
       isLoading: false,
-      value: mergeValues(states.map(s => s.value)),
+      value: mergeValues(states.map((s) => s.value)),
       error: undefined,
     };
     return state;
@@ -32,17 +36,17 @@ export function mergeStates<T>(
 
   if (states.some(isErrorState)) {
     if (mergeErrors === undefined) {
-      mergeErrors = (errors: ErrorState<T>["error"][]) => errors[0];
+      mergeErrors = (errors: ErrorState<T>['error'][]) => errors[0];
     }
 
-    const errorStates = states.filter(isErrorState)
+    const errorStates = states.filter(isErrorState);
     const state: ErrorState<T> = {
       isLoading: false,
       value: undefined,
-      error: mergeErrors(errorStates.map(s => s.error)),
+      error: mergeErrors(errorStates.map((s) => s.error)),
     };
     return state;
-  };
+  }
 
   // If one of the state is still not loaded and there are no errors
   // the merged state is still considered loading.


### PR DESCRIPTION
This fixes issue #10 

---

This PR introduces a function `mergeStates` that allows the user to merge/flatten a list of HttpRequestState objects into a new one based on a transformer function. See the issue and updated Readme for more details. 