### PR TITLE
Added overloads to the loadingState and errorState builder functions …

### DIFF
--- a/libs/ngx-http-request-state/package.json
+++ b/libs/ngx-http-request-state/package.json
@@ -9,7 +9,7 @@
     "loading",
     "error"
   ],
-  "version": "3.2.0",
+  "version": "3.3.0",
   "peerDependencies": {
     "rxjs": "^6.2.0 || ^7.4.0",
     "@angular/common": "^14.2.10 || ^15.0.1 || ^16.0.0 || ^17.0.0 || ^18.0.0"

--- a/libs/ngx-http-request-state/src/lib/builders.ts
+++ b/libs/ngx-http-request-state/src/lib/builders.ts
@@ -12,7 +12,6 @@ import { HttpErrorResponse } from '@angular/common/http';
  *
  * @param value may be provided to indicate the previously-loaded, or last-known, state
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
 export function loadingState<T>(value: T): LoadingStateWithValue<T>;
 export function loadingState<T = never>(): LoadingState<T>;
 export function loadingState<T = never>(value?: T): LoadingState<T> {

--- a/libs/ngx-http-request-state/src/lib/builders.ts
+++ b/libs/ngx-http-request-state/src/lib/builders.ts
@@ -1,4 +1,10 @@
-import { ErrorState, LoadedState, LoadingState } from './model';
+import {
+  ErrorState,
+  ErrorStateWithValue,
+  LoadedState,
+  LoadingState,
+  LoadingStateWithValue,
+} from './model';
 import { HttpErrorResponse } from '@angular/common/http';
 
 /**
@@ -7,22 +13,28 @@ import { HttpErrorResponse } from '@angular/common/http';
  * @param value may be provided to indicate the previously-loaded, or last-known, state
  */
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const loadingState = <T = any>(value?: T): LoadingState<T> => ({
-  isLoading: true,
-  value,
-  error: undefined,
-});
+export function loadingState<T>(value: T): LoadingStateWithValue<T>;
+export function loadingState<T = never>(): LoadingState<T>;
+export function loadingState<T = never>(value?: T): LoadingState<T> {
+  return {
+    isLoading: true,
+    value,
+    error: undefined,
+  };
+}
 
 /**
  * Returns a new LoadedState instance, with the optional value as the loaded data.
  *
  * @param value
  */
-export const loadedState = <T>(value: T): LoadedState<T> => ({
-  isLoading: false,
-  error: undefined,
-  value,
-});
+export function loadedState<T>(value: T): LoadedState<T> {
+  return {
+    isLoading: false,
+    error: undefined,
+    value,
+  };
+}
 
 /**
  * Returns a new ErrorState instance with the given error and optional last-known value.
@@ -30,12 +42,20 @@ export const loadedState = <T>(value: T): LoadedState<T> => ({
  * @param error
  * @param value may be provided to indicate the previously-loaded, or last-known, state
  */
-// eslint-disable-next-line @typescript-eslint/no-explicit-any
-export const errorState = <T = any>(
+export function errorState<T>(
+  error: HttpErrorResponse | Error,
+  value: T
+): ErrorStateWithValue<T>;
+export function errorState<T = never>(
+  error: HttpErrorResponse | Error
+): ErrorState<T>;
+export function errorState<T = never>(
   error: HttpErrorResponse | Error,
   value?: T
-): ErrorState<T> => ({
-  isLoading: false,
-  error,
-  value,
-});
+): ErrorState<T> {
+  return {
+    isLoading: false,
+    error,
+    value,
+  };
+}

--- a/libs/ngx-http-request-state/src/lib/model.ts
+++ b/libs/ngx-http-request-state/src/lib/model.ts
@@ -39,6 +39,18 @@ export interface LoadingState<T> extends HttpRequestState<T> {
 }
 
 /**
+ * Represents an in-flight HTTP request to load some data, with some existing
+ * known data already present.
+ *
+ * Useful for loading states with a default value to render while waiting, or
+ * to represent a loading state with previously-loaded data when using a
+ * 'load more' (e.g., infinite scroll) pattern.
+ */
+export interface LoadingStateWithValue<T> extends LoadingState<T> {
+  readonly value: T;
+}
+
+/**
  * Represents a successfully-completed HTTP request, with the given data.
  *
  * A <code>value</code> may be omitted if there is no data to display and such
@@ -60,4 +72,16 @@ export interface ErrorState<T> extends HttpRequestState<T> {
   readonly isLoading: false;
   readonly value?: T;
   readonly error: HttpErrorResponse | Error;
+}
+
+/**
+ * Represents an unsuccessful HTTP request with the failure details given in the
+ * <code>error</code> property, with some pre-existing known data already present.
+ *
+ * Useful for error states with a fallback value to render, or to represent an
+ * error state with previously-loaded data when using a 'load more' (e.g.,
+ * infinite scroll) pattern.
+ */
+export interface ErrorStateWithValue<T> extends ErrorState<T> {
+  readonly value: T;
 }


### PR DESCRIPTION
…to improve inferred typing when using them with a pre-existing value.

Given

```ts

// Given:

interface MyData {
  foo: number;
}

// Then:

const prev: MyData = { foo: 42 };

this.http.get<MyData>('https://example.com/')
  .pipe(
    map(loadedState),
    startWith(loadingState(prev)),
    catchError((e) => of(errorState(e, prev))),
  )
  .subscribe((state) => {
    // Before these changes, `state.value` was inferred as type `MyData | undefined` even though it will never be undefined
    // After these changes, it is correctly inferred as type `MyData` alone.
  })
```